### PR TITLE
Feature ADC Read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 sdkconfig
 sdkconfig.old
 build
+.vscode

--- a/components/analogReader/include/taskAdc.h
+++ b/components/analogReader/include/taskAdc.h
@@ -1,0 +1,19 @@
+#ifndef TASKADC_H
+#define TASKADC_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_system.h"
+#include "esp_spi_flash.h"
+#include "driver/gpio.h"
+#include "driver/adc.h"
+#include "esp_log.h"
+
+void configAdcTask();
+static void task_adc();
+
+
+#endif

--- a/components/analogReader/taskAdc.c
+++ b/components/analogReader/taskAdc.c
@@ -1,0 +1,35 @@
+#include "taskAdc.h"
+
+static const char *TAG = "ADC";
+
+static void task_adc(){
+     int x;
+    uint16_t adc_data[100];
+
+    while (1) {
+        if (ESP_OK == adc_read(&adc_data[0])) {
+            ESP_LOGI(TAG, "adc read: %d\r\n", adc_data[0]);
+        }
+
+        ESP_LOGI(TAG, "adc read fast:\r\n");
+
+        if (ESP_OK == adc_read_fast(adc_data, 100)) {
+            for (x = 0; x < 100; x++) {
+                printf("%d\n", adc_data[x]);
+            }
+        }
+
+        vTaskDelay(1000 / portTICK_RATE_MS);
+    }
+}
+
+void configAdcTask(){
+    adc_config_t adc_config;
+
+    // Depend on menuconfig->Component config->PHY->vdd33_const value
+    // When measuring system voltage(ADC_READ_VDD_MODE), vdd33_const must be set to 255.
+    adc_config.mode = ADC_READ_TOUT_MODE;
+    adc_config.clk_div = 8; // ADC sample collection clock = 80MHz/clk_div = 10MHz
+    ESP_ERROR_CHECK(adc_init(&adc_config));
+    xTaskCreate(task_adc, "task_adc", 1024, NULL, 5, NULL);
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
-idf_component_register(SRCS "hello_world_main.c"
+idf_component_register(SRCS "main.c"
                     INCLUDE_DIRS "")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,2 +1,2 @@
 idf_component_register(SRCS "main.c"
-                    INCLUDE_DIRS "")
+                        INCLUDE_DIRS "components")

--- a/main/hello_world_main.c
+++ b/main/hello_world_main.c
@@ -7,17 +7,42 @@
    CONDITIONS OF ANY KIND, either express or implied.
 */
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_system.h"
 #include "esp_spi_flash.h"
+#include "driver/gpio.h"
+#include "driver/adc.h"
+#include "esp_log.h"
 
+static const char *TAG = "adc example";
+
+static void task_adc(){
+     int x;
+    uint16_t adc_data[100];
+
+    while (1) {
+        if (ESP_OK == adc_read(&adc_data[0])) {
+            ESP_LOGI(TAG, "adc read: %d\r\n", adc_data[0]);
+        }
+
+        ESP_LOGI(TAG, "adc read fast:\r\n");
+
+        if (ESP_OK == adc_read_fast(adc_data, 100)) {
+            for (x = 0; x < 100; x++) {
+                printf("%d\n", adc_data[x]);
+            }
+        }
+
+        vTaskDelay(1000 / portTICK_RATE_MS);
+    }
+}
 
 void app_main()
 {
-    printf("Hello world!\n");
-
-    /* Print chip information */
+     /* Print chip information */
     esp_chip_info_t chip_info;
     esp_chip_info(&chip_info);
     printf("This is ESP8266 chip with %d CPU cores, WiFi, ",
@@ -27,12 +52,17 @@ void app_main()
 
     printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
+    vTaskDelay(5000 / portTICK_RATE_MS);
+    
+    adc_config_t adc_config;
 
-    for (int i = 10; i >= 0; i--) {
-        printf("Restarting in %d seconds...\n", i);
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-    }
-    printf("Restarting now.\n");
-    fflush(stdout);
-    esp_restart();
+    // Depend on menuconfig->Component config->PHY->vdd33_const value
+    // When measuring system voltage(ADC_READ_VDD_MODE), vdd33_const must be set to 255.
+    adc_config.mode = ADC_READ_TOUT_MODE;
+    adc_config.clk_div = 8; // ADC sample collection clock = 80MHz/clk_div = 10MHz
+    ESP_ERROR_CHECK(adc_init(&adc_config));
+
+    xTaskCreate(task_adc, "task_adc", 1024, NULL, 5, NULL);
+
 }
+

--- a/main/main.c
+++ b/main/main.c
@@ -1,11 +1,3 @@
-/* Hello World Example
-
-   This example code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -53,7 +45,7 @@ void app_main()
     printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
     vTaskDelay(5000 / portTICK_RATE_MS);
-    
+
     adc_config_t adc_config;
 
     // Depend on menuconfig->Component config->PHY->vdd33_const value

--- a/main/main.c
+++ b/main/main.c
@@ -1,36 +1,11 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_system.h"
 #include "esp_spi_flash.h"
-#include "driver/gpio.h"
-#include "driver/adc.h"
 #include "esp_log.h"
-
-static const char *TAG = "adc example";
-
-static void task_adc(){
-     int x;
-    uint16_t adc_data[100];
-
-    while (1) {
-        if (ESP_OK == adc_read(&adc_data[0])) {
-            ESP_LOGI(TAG, "adc read: %d\r\n", adc_data[0]);
-        }
-
-        ESP_LOGI(TAG, "adc read fast:\r\n");
-
-        if (ESP_OK == adc_read_fast(adc_data, 100)) {
-            for (x = 0; x < 100; x++) {
-                printf("%d\n", adc_data[x]);
-            }
-        }
-
-        vTaskDelay(1000 / portTICK_RATE_MS);
-    }
-}
+#include "taskAdc.h"
 
 void app_main()
 {
@@ -44,17 +19,10 @@ void app_main()
 
     printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
+    
+    ESP_LOGI("TASK", "Initialize adc task\r\n");
     vTaskDelay(5000 / portTICK_RATE_MS);
 
-    adc_config_t adc_config;
-
-    // Depend on menuconfig->Component config->PHY->vdd33_const value
-    // When measuring system voltage(ADC_READ_VDD_MODE), vdd33_const must be set to 255.
-    adc_config.mode = ADC_READ_TOUT_MODE;
-    adc_config.clk_div = 8; // ADC sample collection clock = 80MHz/clk_div = 10MHz
-    ESP_ERROR_CHECK(adc_init(&adc_config));
-
-    xTaskCreate(task_adc, "task_adc", 1024, NULL, 5, NULL);
-
+    configAdcTask();
 }
 


### PR DESCRIPTION
# Clean archteture
This pull request put a feature to execute adc read using "external components".
It was added:
- ./components/analogReader
- On ./main/CMakeList.txt was include 'INCLUDE_DIRS "components"' due to use external component (strongly recommmended to prevent errors)